### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-01-25
+
+### Changed
+- Upgraded spectra dependency from 0.3.0 to 0.3.1
+- Improved type specifications to use `dynamic()` instead of `term()` for runtime-determined types
+- Updated project documentation to remove hardcoded dependency version references
+
 ## [0.3.0] - 2026-01-20
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Spectral is an Elixir wrapper library for the Erlang `spectra` library (v0.1.9). It provides idiomatic Elixir interfaces for:
+Spectral is an Elixir wrapper library for the Erlang `spectra` library. It provides idiomatic Elixir interfaces for:
 - **Data encoding/decoding**: Convert Elixir structs to/from JSON using type specifications
 - **Schema generation**: Generate JSON schemas from Elixir type definitions
 - **OpenAPI specification**: Generate OpenAPI 3.0 specifications from type definitions

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ Spectral.encode(data, module, type_ref, format \\ :json) ::
 Spectral.encode!(data, module, type_ref, format \\ :json) :: iodata()
 
 Spectral.decode(data, module, type_ref, format \\ :json) ::
-    {:ok, term()} | {:error, [%Spectral.Error{}]}
+    {:ok, dynamic()} | {:error, [%Spectral.Error{}]}
 
-Spectral.decode!(data, module, type_ref, format \\ :json) :: term()
+Spectral.decode!(data, module, type_ref, format \\ :json) :: dynamic()
 ```
 
 **Parameters:**
@@ -353,9 +353,11 @@ Example:
 }
 ```
 
-### `term()` and `any()`
+### `dynamic()`, `term()` and `any()`
 
-When using types with `term()` or `any()`, Spectral will not reject any data, which means it can return data that may not be valid JSON.
+When using types with `dynamic()`, `term()`, or `any()` in your type specifications, Spectral will not reject any data, which means it can return data that may not be valid JSON.
+
+Note: Spectral uses `dynamic()` for runtime-determined types in its own API, following Erlang's gradual typing conventions.
 
 ### Unsupported Types
 

--- a/lib/spectral.ex
+++ b/lib/spectral.ex
@@ -46,7 +46,7 @@ defmodule Spectral do
       iex> IO.iodata_to_binary(json)
       ~s({"name":"Alice"})
   """
-  @spec encode(term(), module(), atom(), atom()) ::
+  @spec encode(dynamic(), module(), atom(), atom()) ::
           {:ok, iodata()} | {:error, [Spectral.Error.t()]}
   def encode(data, module, type_ref, format \\ :json) do
     :spectra.encode(format, module, type_ref, data)
@@ -68,7 +68,7 @@ defmodule Spectral do
 
   ## Returns
 
-  - `{:ok, term()}` - Decoded data on success
+  - `{:ok, dynamic()}` - Decoded data on success
   - `{:error, [%Spectral.Error{}]}` - List of errors on failure
 
   ## Examples
@@ -85,8 +85,8 @@ defmodule Spectral do
       ...> |> Spectral.decode(Person, :t)
       {:ok, %Person{age: 30, name: "Alice", address: nil}}
   """
-  @spec decode(term(), module(), atom(), atom()) ::
-          {:ok, term()} | {:error, [Spectral.Error.t()]}
+  @spec decode(binary(), module(), atom(), atom()) ::
+          {:ok, dynamic()} | {:error, [Spectral.Error.t()]}
   def decode(data, module, type_ref, format \\ :json) do
     :spectra.decode(format, module, type_ref, data)
     |> convert_result()
@@ -152,7 +152,7 @@ defmodule Spectral do
       ...> |> IO.iodata_to_binary()
       ~s({"age":30,"name":"Alice"})
   """
-  @spec encode!(term(), module(), atom(), atom()) :: iodata()
+  @spec encode!(dynamic(), module(), atom(), atom()) :: iodata()
   def encode!(data, module, type_ref, format \\ :json) do
     case encode(data, module, type_ref, format) do
       {:ok, result} ->
@@ -177,7 +177,7 @@ defmodule Spectral do
 
   ## Returns
 
-  - `term()` - Decoded data on success
+  - `dynamic()` - Decoded data on success
 
   ## Raises
 
@@ -189,7 +189,7 @@ defmodule Spectral do
       ...> |> Spectral.decode!(Person, :t)
       %Person{age: 30, name: "Alice", address: nil}
   """
-  @spec decode!(term(), module(), atom(), atom()) :: term()
+  @spec decode!(binary(), module(), atom(), atom()) :: dynamic()
   def decode!(data, module, type_ref, format \\ :json) do
     case decode(data, module, type_ref, format) do
       {:ok, result} ->

--- a/lib/spectral/error.ex
+++ b/lib/spectral/error.ex
@@ -11,7 +11,7 @@ defmodule Spectral.Error do
 
   - `:location` - Path to where the error occurred (list of strings or atoms)
   - `:type` - Type of error (`:decode_error`, `:type_mismatch`, `:no_match`, `:missing_data`, `:not_matched_fields`)
-  - `:context` - Additional context information about the error (any term)
+  - `:context` - Additional context information about the error (runtime-determined type)
   - `:message` - Human-readable error message (auto-generated for exceptions)
 
   ## Example
@@ -29,7 +29,7 @@ defmodule Spectral.Error do
   @type t :: %__MODULE__{
           location: [String.t() | atom()],
           type: error_type(),
-          context: term(),
+          context: dynamic(),
           message: String.t()
         }
 

--- a/lib/spectral/openapi.ex
+++ b/lib/spectral/openapi.ex
@@ -271,7 +271,7 @@ defmodule Spectral.OpenAPI do
 
       {:ok, openapi_spec} = Spectral.OpenAPI.endpoints_to_openapi(metadata, endpoints)
   """
-  @spec endpoints_to_openapi(map(), [term()]) ::
+  @spec endpoints_to_openapi(map(), [dynamic()]) ::
           {:ok, map()} | {:error, [Spectral.Error.t()]}
   def endpoints_to_openapi(metadata, endpoints) do
     metadata

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Spectral.MixProject do
   def project do
     [
       app: :spectral,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/mix.lock
+++ b/mix.lock
@@ -11,5 +11,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "1.0.1", "e928a4f984e795e41e3abd27bfc09f51db16ab8ba1aebdba2b3a575437efafc2", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "7284900d412a3e5cfd97fdaed4f5ed389b8f2b4cb49efc0eb3bd10e2febf9507"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.2", "03e1804074b3aa64d5fad7aa64601ed0fb395337b982d9bcf04029d68d51b6a7", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "af33ff7ef368d5893e4a267933e7744e46ce3cf1f61e2dccf53a111ed3aa3727"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
-  "spectra": {:hex, :spectra, "0.3.0", "9d1f869a0006932b7d9cfea245918a14685515607bc211e2759fca3e86a037ad", [:rebar3], [], "hexpm", "b453f123c84fbfc28770a8d359a573e90816be71aee34cb8535d76033d524400"},
+  "spectra": {:hex, :spectra, "0.3.1", "5b1956bdb261fe72939f729e7114c65a89b95b1252a325ead46a1bd690b1fd0f", [:rebar3], [], "hexpm", "d0d4bd33be9683eda519224155c3da05aed6da40030d8f6618f738e4ad6da597"},
 }


### PR DESCRIPTION
- Upgrade spectra dependency from 0.3.0 to 0.3.1
- Use dynamic() instead of term() for runtime-determined types
- Use binary() for decode input (was term())
- Remove hardcoded version references from documentation

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
