### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-01-27
+
+### Changed
+- Upgraded spectra dependency from 0.3.2 to 0.4.0
+- **BREAKING CHANGE**: `Spectral.schema/3` now returns `iodata()` directly instead of `{:ok, iodata()}` tuple, matching the new spectra 0.4.0 API
+
+### Removed
+- **BREAKING CHANGE**: Removed `Spectral.schema!/3` function as it's no longer needed (schema/3 now returns directly)
+
 ## [0.3.2] - 2026-01-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add `spectral` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:spectral, "~> 0.3.2"}
+    {:spectral, "~> 0.4.0"}
   ]
 end
 ```
@@ -66,9 +66,8 @@ json_string = ~s({"name":"Alice","age":30,"address":{"street":"Ystader Straße",
 {:ok, person} = Spectral.decode(json_string, Person, :t)
 
 # Generate a JSON schema
-with {:ok, schema_iodata} <- Spectral.schema(Person, :t) do
-  IO.iodata_to_binary(schema_iodata)
-end
+schema_iodata = Spectral.schema(Person, :t)
+IO.iodata_to_binary(schema_iodata)
 ```
 
 ### Bang Functions
@@ -87,7 +86,7 @@ person =
 
 schema =
   Person
-  |> Spectral.schema!(:t)
+  |> Spectral.schema(:t)
   |> IO.iodata_to_binary()
 ```
 
@@ -157,10 +156,7 @@ Spectral.decode!(data, module, type_ref, format \\ :json) :: dynamic()
 Generate schemas from your type definitions:
 
 ```elixir
-Spectral.schema(module, type_ref, format \\ :json_schema) ::
-    {:ok, iodata()} | {:error, [%Spectral.Error{}]}
-
-Spectral.schema!(module, type_ref, format \\ :json_schema) :: iodata()
+Spectral.schema(module, type_ref, format \\ :json_schema) :: iodata()
 ```
 
 **Parameters:**
@@ -294,7 +290,7 @@ Spectral provides two types of functions with different error handling strategie
 
 ### Normal Functions
 
-The standard functions (`encode/3-4`, `decode/3-4`, `schema/2-3`) use a dual error handling approach:
+The encoding and decoding functions (`encode/3-4`, `decode/3-4`) use a dual error handling approach:
 
 **Data validation errors** return `{:error, [%Spectral.Error{}]}` tuples:
 - Type mismatches (e.g., string when integer expected)
@@ -321,7 +317,7 @@ These exceptions indicate problems with your application's configuration or type
 
 ### Bang Functions
 
-The bang versions (`encode!/3-4`, `decode!/3-4`, `schema!/2-3`) always raise exceptions for any error:
+The bang versions (`encode!/3-4`, `decode!/3-4`) always raise exceptions for any error:
 
 ```elixir
 person =
@@ -331,6 +327,17 @@ person =
 ```
 
 Use bang functions when you want to propagate all errors as exceptions, simplifying pipelines but requiring try/rescue for error handling.
+
+### Schema Generation
+
+The `schema/2-3` function returns the schema directly as `iodata()` without wrapping it in a result tuple:
+
+```elixir
+schema = Spectral.schema(Person, :t)
+IO.iodata_to_binary(schema)
+```
+
+Schema generation may still raise exceptions for type and configuration errors (module not found, type not found, etc.).
 
 ### Error Structure
 

--- a/lib/spectral.ex
+++ b/lib/spectral.ex
@@ -106,20 +106,17 @@ defmodule Spectral do
 
   ## Returns
 
-  - `{:ok, iodata()}` - Generated schema on success
-  - `{:error, [%Spectral.Error{}]}` - List of errors on failure
+  - `iodata()` - Generated schema
 
   ## Examples
 
-      iex> {:ok, schemadata} = Spectral.schema(Person, :t)
+      iex> schemadata = Spectral.schema(Person, :t)
       iex> is_binary(IO.iodata_to_binary(schemadata))
       true
   """
-  @spec schema(module(), atom(), atom()) ::
-          {:ok, iodata()} | {:error, [Spectral.Error.t()]}
+  @spec schema(module(), atom(), atom()) :: iodata()
   def schema(module, type_ref, format \\ :json_schema) do
     :spectra.schema(format, module, type_ref)
-    |> convert_result()
   rescue
     error in ErlangError ->
       handle_erlang_error(error, :schema, module, type_ref)
@@ -196,43 +193,6 @@ defmodule Spectral do
         result
 
       {:error, [error | _]} ->
-        raise Spectral.Error.exception(error)
-    end
-  end
-
-  @doc """
-  Generates a schema for the specified type, raising on error.
-
-  Like `schema/3` but raises `Spectral.Error` instead of returning an error tuple.
-
-  ## Parameters
-
-  - `module` - Module containing the type definition
-  - `type_ref` - Type reference (typically an atom like `:t`)
-  - `format` - Schema format (default: `:json_schema`)
-
-  ## Returns
-
-  - `iodata()` - Generated schema on success
-
-  ## Raises
-
-  - `Spectral.Error` - If schema generation fails
-
-  ## Examples
-
-      iex> schemadata = Spectral.schema!(Person.Address, :t)
-      iex> IO.iodata_to_binary(schemadata)
-      ~s({"type":"object","required":["street","city"],"additionalProperties":false,"properties":{"city":{"type":"string"},"street":{"type":"string"}},"$schema":"https://json-schema.org/draft/2020-12/schema"})
-  """
-  @spec schema!(module(), atom(), atom()) :: iodata()
-  def schema!(module, type_ref, format \\ :json_schema) do
-    case schema(module, type_ref, format) do
-      {:ok, result} ->
-        result
-
-      {:error, [error | _]} ->
-        # Call exception/1 to populate the message field
         raise Spectral.Error.exception(error)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Spectral.MixProject do
   def project do
     [
       app: :spectral,
-      version: "0.3.2",
+      version: "0.4.0",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       description: description(),
@@ -24,7 +24,7 @@ defmodule Spectral.MixProject do
 
   defp deps do
     [
-      {:spectra, "~> 0.3.2"},
+      {:spectra, "~> 0.4.0"},
       # Code quality tools
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4.7", only: [:dev], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -11,5 +11,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "1.0.1", "e928a4f984e795e41e3abd27bfc09f51db16ab8ba1aebdba2b3a575437efafc2", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "7284900d412a3e5cfd97fdaed4f5ed389b8f2b4cb49efc0eb3bd10e2febf9507"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.2", "03e1804074b3aa64d5fad7aa64601ed0fb395337b982d9bcf04029d68d51b6a7", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "af33ff7ef368d5893e4a267933e7744e46ce3cf1f61e2dccf53a111ed3aa3727"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
-  "spectra": {:hex, :spectra, "0.3.2", "e487ecf6178cb04367465121884d35c6e81c3bd80c67a6c95ea09c10b0a08576", [:rebar3], [], "hexpm", "fcabc6d99f7ccec6b01cc3ad1bd73077ea5f546b57d46ad8dcb9c84d09fb9f2e"},
+  "spectra": {:hex, :spectra, "0.4.0", "1a5390e55b34f83693998fd7ecbc448bcdc5fc5ebcca790c7b0dd2d6a0fed255", [:rebar3], [], "hexpm", "e51e88be6eb3b85a1e3d0a9651a9f76aca5a83a1ef940467541b77d078c5fb84"},
 }

--- a/test/spectral_test.exs
+++ b/test/spectral_test.exs
@@ -76,9 +76,9 @@ defmodule SpectralTest do
              Spectral.decode!(~s({"name":"Alice","age":30}), Person, :t)
   end
 
-  test "schema! returns result directly" do
+  test "schema returns result directly" do
     assert ~s({"type":"object","required":["street","city"],"additionalProperties":false,"properties":{"city":{"type":"string"},"street":{"type":"string"}},"$schema":"https://json-schema.org/draft/2020-12/schema"}) ==
-             Spectral.schema!(Person.Address, :t)
+             Spectral.schema(Person.Address, :t)
              |> IO.iodata_to_binary()
   end
 


### PR DESCRIPTION
## Changed
- Upgraded spectra dependency from 0.3.2 to 0.4.0
- **BREAKING CHANGE**: `Spectral.schema/3` now returns `iodata()` directly instead of `{:ok, iodata()}` tuple, matching the new spectra 0.4.0 API

## Removed
- **BREAKING CHANGE**: Removed `Spectral.schema!/3` function as it's no longer needed (schema/3 now returns directly)

## Release Checklist

- [x] Version updated in mix.exs
- [x] CHANGELOG.md updated
- [x] All tests passing
- [x] Documentation updated
- [ ] PR reviewed and approved
- [ ] Merge to main
- [ ] Run `make release` to tag and publish

## Migration Guide

Users upgrading from 0.3.x will need to update their code:

**Before (0.3.x)**:
```elixir
with {:ok, schema} <- Spectral.schema(Person, :t) do
  IO.iodata_to_binary(schema)
end

# Or with bang version
schema = Spectral.schema!(Person, :t)
```

**After (0.4.0)**:
```elixir
schema = Spectral.schema(Person, :t)
IO.iodata_to_binary(schema)
```

The `schema!/3` function has been removed. Use `schema/3` directly as it now returns the result without wrapping it in a tuple.