### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-03-02
+
+### Added
+- `opts` parameter to `encode/5`, `decode/5`, `encode!/5`, and `decode!/5` for passing options to the underlying spectra library (backward-compatible: defaults to `[]`)
+- `:pre_encoded` option for `encode/5`/`encode!/5`: returns intermediate JSON term (map/list) instead of iodata
+- `:pre_decoded` option for `decode/5`/`decode!/5`: accepts an already-decoded JSON term as input, skipping JSON parsing
+
+### Changed
+- Upgraded spectra dependency from 0.5.0 to 0.5.1
+- spectra 0.5.1 adds performance improvements via `persistent_term` caching for `__spectra_type_info__/0` calls
+
 ## [0.5.0] - 2026-02-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add `spectral` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:spectral, "~> 0.5.0"}
+    {:spectral, "~> 0.5.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Spectral.MixProject do
   def project do
     [
       app: :spectral,
-      version: "0.5.0",
+      version: "0.5.1",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
## Changes

- Added `opts` parameter to `encode/5`, `decode/5`, `encode!/5`, and `decode!/5` (backward-compatible, defaults to `[]`)
- Added `:pre_encoded` option for `encode/5`/`encode!/5`: returns intermediate JSON term instead of iodata
- Added `:pre_decoded` option for `decode/5`/`decode!/5`: accepts pre-decoded JSON term, skipping JSON parsing
- Upgraded spectra dependency from 0.5.0 to 0.5.1 (adds `persistent_term` caching for performance)

## Release Checklist

- [x] Version updated in mix.exs
- [x] CHANGELOG.md updated
- [x] All tests passing
- [x] Documentation updated
- [ ] PR reviewed and approved
- [ ] Merge to main
- [ ] Run `make release` to tag and publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)