### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-03-04
+
+### Added
+- `spectral/1` macro can now be placed before `@spec` definitions to attach endpoint documentation (`summary`, `description`, `deprecated`) to functions
+- `Spectral.TypeInfo.get_function_doc/3` — retrieves endpoint documentation stored in a function's `sp_function_spec` metadata; returns `{:ok, doc}`, `{:error, :no_doc_found}`, or `{:error, :function_not_found}`
+- `Spectral.OpenAPI.endpoint/5` — 5-argument overload that reads a function's `spectral/1` metadata from the module's type info and uses it as the OpenAPI operation documentation; raises `ArgumentError` if the function has no `spectral/1` annotation
+
+### Changed
+- Upgraded spectra dependency from `~> 0.5.1` to `~> 0.6.0`
+- spectra 0.6.0 fixes the `sp_union` record default value (no user-facing impact)
+
 ## [0.5.1] - 2026-03-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add `spectral` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:spectral, "~> 0.5.1"}
+    {:spectral, "~> 0.6.0"}
   ]
 end
 ```
@@ -216,6 +216,27 @@ defmodule MyModule do
 end
 ```
 
+### Documenting Functions (Endpoint Metadata)
+
+The `spectral` macro also works before `@spec` definitions to attach OpenAPI endpoint documentation to functions:
+
+```elixir
+defmodule MyController do
+  use Spectral
+
+  spectral summary: "Get user", description: "Returns a user by ID"
+  @spec show(map(), map()) :: map()
+  def show(_conn, _params), do: %{}
+end
+```
+
+**Supported fields:**
+- `summary` - Short summary of the endpoint operation
+- `description` - Longer description of the operation
+- `deprecated` - Whether the endpoint is deprecated (boolean)
+
+This metadata is used by `Spectral.OpenAPI.endpoint/5` to automatically populate OpenAPI operation fields — see the OpenAPI section below.
+
 ## OpenAPI Specification
 
 Spectral can generate complete [OpenAPI 3.0](https://spec.openapis.org/oas/v3.0.0) specifications for your REST APIs. This provides interactive documentation, client generation, and API testing tools.
@@ -271,12 +292,22 @@ response_with_headers =
 
 #### Building Endpoints
 
-Endpoints are built by combining the endpoint definition with responses, request bodies, and parameters:
-Responses are taken from the previous section.
+Endpoints are built by combining the endpoint definition with responses, request bodies, and parameters.
+
+Use `endpoint/5` to automatically pull the endpoint documentation from a function's `spectral/1` annotation:
+
+```elixir
+# Documentation comes from the spectral/1 annotation on MyController.show/2
+user_get_endpoint =
+  Spectral.OpenAPI.endpoint(:get, "/users/{id}", MyController, :show, 2)
+  |> Spectral.OpenAPI.add_response(user_found_response)
+```
+
+Or use `endpoint/3` to pass documentation inline:
 
 ```elixir
 user_get_endpoint =
-  Spectral.OpenAPI.endpoint(:get, "/users/{id}")
+  Spectral.OpenAPI.endpoint(:get, "/users/{id}", %{summary: "Get user by ID"})
   |> Spectral.OpenAPI.with_parameter(Person, %{
     name: "id",
     in: :path,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Spectral.MixProject do
   def project do
     [
       app: :spectral,
-      version: "0.5.1",
+      version: "0.6.0",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
## Changes

- Added `spectral/1` macro support before `@spec` definitions to attach endpoint documentation (`summary`, `description`, `deprecated`) to functions
- Added `Spectral.TypeInfo.get_function_doc/3` for retrieving function endpoint documentation from type info
- Added `Spectral.OpenAPI.endpoint/5` that auto-populates OpenAPI operation fields from a function's `spectral/1` annotation; raises `ArgumentError` if the function has no annotation
- Upgraded spectra dependency from `~> 0.5.1` to `~> 0.6.0` (sp_union default value fix)
- Updated README with function annotation documentation and `endpoint/5` usage

## Release Checklist

- [x] Version updated in mix.exs
- [x] CHANGELOG.md updated
- [x] All tests passing
- [x] Documentation updated
- [ ] PR reviewed and approved
- [ ] Merge to main
- [ ] Run `make release` to tag and publish