### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-03-21
+
+### Added
+- `Spectral.schema/4` — accepts an options list as the last argument, supporting the `:pre_encoded` option to return a map instead of iodata
+- `Spectral.OpenAPI.endpoints_to_openapi/3` — accepts an options list, supporting the same `:pre_encoded` option
+- `schema_option/0` type for the new options
+
+### Changed
+- Upgraded spectra dependency from `~> 0.8.0` to `~> 0.8.1`
+- `Spectral.OpenAPI` specs now use precise exported spectra types (`endpoint_spec`, `response_spec`, `openapi_metadata`, etc.) instead of `dynamic()` / `map()`
+- README revised: requirements merged into installation, sections reordered, Options table added, string/binary constraints documented, `examples_function` documented
+
 ## [0.8.0] - 2026-03-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add `spectral` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:spectral, "~> 0.8.0"}
+    {:spectral, "~> 0.8.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Spectral.MixProject do
   def project do
     [
       app: :spectral,
-      version: "0.8.0",
+      version: "0.8.1",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
## Changes

- Added `Spectral.schema/4` with `:pre_encoded` option support
- Added `Spectral.OpenAPI.endpoints_to_openapi/3` with options support
- Added `schema_option/0` type
- Upgraded spectra dependency from `~> 0.8.0` to `~> 0.8.1`
- `Spectral.OpenAPI` specs now use precise exported spectra types
- README revised: requirements merged into installation, sections reordered, Options table, string/binary constraints, and `examples_function` documented

## Release Checklist

- [x] Version updated in mix.exs
- [x] CHANGELOG.md updated
- [x] All tests passing
- [x] Documentation updated
- [ ] PR reviewed and approved
- [ ] Merge to main
- [ ] Run `make release` to tag and publish