### PR TITLE
Fix OpenAPI version references: 3.0 → 3.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Guidance for agentic coding agents working in this repository.
 Spectral is a thin Elixir wrapper around the Erlang `:spectra` library. It provides:
 - **Type-safe JSON encoding/decoding** via `Spectral.encode/4` and `Spectral.decode/4`
 - **JSON Schema generation** via `Spectral.schema/3`
-- **OpenAPI 3.0 spec generation** via `Spectral.OpenAPI`
+- **OpenAPI 3.1 spec generation** via `Spectral.OpenAPI`
 - **Type documentation** via the `spectral/1` macro (`use Spectral`)
 
 Most implementation complexity lives in `:spectra`/`:spectra_openapi`. Spectral's job is idiomatic Elixir delegation.

--- a/lib/spectral/openapi.ex
+++ b/lib/spectral/openapi.ex
@@ -2,7 +2,7 @@ defmodule Spectral.OpenAPI do
   @moduledoc """
   Elixir wrapper for spectra OpenAPI specification generation.
 
-  This module provides idiomatic Elixir functions for generating OpenAPI 3.0
+  This module provides idiomatic Elixir functions for generating OpenAPI 3.1
   specifications from Elixir type definitions using spectra.
 
   ## Response Builder Pattern

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Spectral.MixProject do
 
   defp description() do
     """
-    Spectral provides type-driven JSON encoding/decoding, JSON Schema generation, and OpenAPI 3.0
+    Spectral provides type-driven JSON encoding/decoding, JSON Schema generation, and OpenAPI 3.1
     specification generation. It uses Elixir's type system to automatically handle serialization
     based on struct type definitions.
     """


### PR DESCRIPTION
Three places incorrectly referred to OpenAPI 3.0 — updated to 3.1.

- `mix.exs` package description
- `lib/spectral/openapi.ex` moduledoc
- `AGENTS.md` project overview