### PR TITLE
Release 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-04-01
+
+### Changed
+- Upgraded spectra dependency to `~> 0.9.3`
+- Internal: replaced O(N²) spectral pairing loop with an O(N log N) state machine — no behaviour change, compile times for large modules may improve
+- README: added Configuration section documenting `spectra` application environment options
+
 ## [0.9.1] - 2026-03-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add `spectral` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:spectral, "~> 0.9.1"}
+    {:spectral, "~> 0.9.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Spectral.MixProject do
   def project do
     [
       app: :spectral,
-      version: "0.9.1",
+      version: "0.9.2",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
## Summary

- Upgraded spectra dependency to `~> 0.9.3`
- Internal: replaced O(N²) spectral pairing loop with an O(N log N) state machine — no behaviour change, compile times for large modules may improve
- README: added Configuration section documenting `spectra` application environment options

## Changelog

### [0.9.2] - 2026-04-01

#### Changed
- Upgraded spectra dependency to `~> 0.9.3`
- Internal: replaced O(N²) spectral pairing loop with an O(N log N) state machine — no behaviour change, compile times for large modules may improve
- README: added Configuration section documenting `spectra` application environment options

## Notes

- Do **not** merge until ready to publish — `make release` handles tagging and hex.pm publish after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)