### PR TITLE
Evaluate spectra claude/mystifying-dirac-930c38: add field_aliases support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-07
+
+### Added
+- `field_aliases` option in the `spectral/1` macro: map Elixir field name atoms to custom JSON key binaries (e.g. `field_aliases: %{first_name: "firstName"}`). Works for struct types and map literal fields. Applies after `only` filtering and is reflected in generated JSON Schemas.
+- `field_aliases` and `only` now propagate through type aliases — both local user-type references and remote module types. Transforms declared on a type alias are applied when the reference is resolved during encode/decode/schema generation.
+
+### Changed
+- Upgraded spectra dependency to `~> 0.13.1`
+
 ## [0.12.0] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `field_aliases` option in the `spectral/1` macro: map Elixir field name atoms to custom JSON key binaries (e.g. `field_aliases: %{first_name: "firstName"}`). Works for struct types and map literal fields. Applies after `only` filtering and is reflected in generated JSON Schemas.
 - `field_aliases` and `only` now propagate through type aliases — both local user-type references and remote module types. Transforms declared on a type alias are applied when the reference is resolved during encode/decode/schema generation.
 
-### Changed
-- Upgraded spectra dependency to `~> 0.13.1`
-
 ## [0.12.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add `spectral` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:spectral, "~> 0.12.0"}
+    {:spectral, "~> 0.13.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ Spectral.encode(%User{first_name: "Alice", last_name: "Smith", birth_year: 1990}
 # {:ok, ~s({"firstName":"Alice","lastName":"Smith","birth_year":1990})}
 
 Spectral.decode(~s({"firstName":"Bob","lastName":"Jones","birth_year":1985}), User, :t)
-# {:ok, %User{first_name: "Bob", last_name: "Smith", birth_year: 1985}}
+# {:ok, %User{first_name: "Bob", last_name: "Jones", birth_year: 1985}}
 ```
 
 Field aliases apply to both struct types and plain map literal fields. Aliases are also reflected in generated JSON Schemas — the schema property name uses the aliased key.

--- a/README.md
+++ b/README.md
@@ -568,11 +568,14 @@ Spectral.decode(~s({"id":1,"name":"Alice","email":"alice@example.com"}), User, :
 Excluded fields present in the incoming JSON are silently ignored. Fields excluded by `only`
 are filled from the struct's default values on decode (see [Struct defaults](#struct-defaults)).
 
-`only` also works on union types such as `MyStruct | nil`:
+`only` also works on union types such as `MyStruct | nil`, and propagates through type aliases (local or remote):
 
 ```elixir
 spectral only: [:id, :name]
 @type t_or_nil :: %User{...} | nil
+
+spectral only: [:id, :name]
+@type public_t :: OtherModule.t()  # only is applied when the reference is resolved
 ```
 
 #### Ecto schemas and `only`
@@ -700,6 +703,13 @@ When combined with `only`, filtering happens first and aliases are applied to th
 ```elixir
 spectral only: [:first_name, :last_name], field_aliases: %{first_name: "firstName"}
 @type public_t :: %User{...}
+```
+
+`field_aliases` also propagates through type aliases — local references and remote module types:
+
+```elixir
+spectral field_aliases: %{first_name: "firstName"}
+@type camel_t :: OtherModule.t()  # alias applied when the reference is resolved
 ```
 
 ### Documenting Functions (Endpoint Metadata)

--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ end
 - `examples_function` — `{module, function_name, args}` tuple; the function is called at schema generation time to produce examples. Use this instead of `examples` when constructing values inline is awkward. The function must be exported.
 - `type_parameters` — passed as `params` to codec callbacks (see [Custom Codecs](#custom-codecs))
 - `only` — list of field name atoms to include; all other fields are excluded from encode, decode, and schema generation (see [Field Filtering with `only`](#field-filtering-with-only))
+- `field_aliases` — map of field name atoms to JSON key binaries, e.g. `%{first_name: "firstName"}`; applied after `only` filtering (see [Field Aliases](#field-aliases))
 
 ```elixir
 defmodule Person do
@@ -665,6 +666,41 @@ Spectral.encode(%MyApp.User{name: "Alice", email: "alice@example.com"}, MyApp.Us
 
 `DateTime.t() | nil` requires the `Spectral.Codec.DateTime` codec to be registered — see
 [Built-in Codecs](#built-in-codecs).
+
+### Field Aliases
+
+The `field_aliases` key maps Erlang/Elixir field name atoms to custom JSON key binaries. This lets you expose camelCase (or any other naming convention) in your API while keeping snake_case internally.
+
+```elixir
+defmodule User do
+  use Spectral
+  defstruct [:first_name, :last_name, :birth_year]
+
+  spectral field_aliases: %{first_name: "firstName", last_name: "lastName"}
+  @type t :: %User{
+          first_name: String.t() | nil,
+          last_name: String.t() | nil,
+          birth_year: non_neg_integer() | nil
+        }
+end
+```
+
+```elixir
+Spectral.encode(%User{first_name: "Alice", last_name: "Smith", birth_year: 1990}, User, :t)
+# {:ok, ~s({"firstName":"Alice","lastName":"Smith","birth_year":1990})}
+
+Spectral.decode(~s({"firstName":"Bob","lastName":"Jones","birth_year":1985}), User, :t)
+# {:ok, %User{first_name: "Bob", last_name: "Smith", birth_year: 1985}}
+```
+
+Field aliases apply to both struct types and plain map literal fields. Aliases are also reflected in generated JSON Schemas — the schema property name uses the aliased key.
+
+When combined with `only`, filtering happens first and aliases are applied to the remaining fields:
+
+```elixir
+spectral only: [:first_name, :last_name], field_aliases: %{first_name: "firstName"}
+@type public_t :: %User{...}
+```
 
 ### Documenting Functions (Endpoint Metadata)
 

--- a/lib/spectral.ex
+++ b/lib/spectral.ex
@@ -91,6 +91,9 @@ defmodule Spectral do
   - `only` - List of field name atoms to include when encoding, decoding, and generating
     schemas. Fields not in the list are silently dropped. For Elixir structs, excluded
     fields are filled from the struct's defaults on decode.
+  - `field_aliases` - Map of field name atoms (or integers for integer map keys) to JSON
+    key binaries, e.g. `%{first_name: "firstName"}`. Applies to struct fields and map
+    literal keys. Applied after `only` filtering.
 
   ## Fields — before a `@spec`
 
@@ -310,12 +313,22 @@ defmodule Spectral do
     case Map.fetch(type_doc_map, {name, arity}) do
       {:ok, doc} ->
         {type_params, doc1} = Map.pop(doc, :type_parameters)
-        {only, doc_clean} = Map.pop(doc1, :only)
+        {only, doc2} = Map.pop(doc1, :only)
+        {field_aliases_raw, doc_clean} = Map.pop(doc2, :field_aliases)
 
         tagged
         |> then(fn t ->
           if only != nil,
             do: :spectra_abstract_code.apply_only(t, validate_only(only)),
+            else: t
+        end)
+        |> then(fn t ->
+          if field_aliases_raw != nil,
+            do:
+              :spectra_abstract_code.apply_field_aliases(
+                t,
+                validate_field_aliases(field_aliases_raw)
+              ),
             else: t
         end)
         |> :spectra_type.add_doc_to_type(doc_clean)
@@ -373,6 +386,23 @@ defmodule Spectral do
 
   defp validate_only(only) do
     raise ArgumentError, "spectral :only must be a list of atoms, got: #{inspect(only)}"
+  end
+
+  defp validate_field_aliases(aliases) when is_map(aliases) do
+    Enum.each(aliases, fn
+      {k, v} when (is_atom(k) or is_integer(k)) and is_binary(v) ->
+        :ok
+
+      {k, v} ->
+        raise ArgumentError,
+              "spectral :field_aliases keys must be atoms or integers and values must be binaries, got: #{inspect({k, v})}"
+    end)
+
+    aliases
+  end
+
+  defp validate_field_aliases(other) do
+    raise ArgumentError, "spectral :field_aliases must be a map, got: #{inspect(other)}"
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,8 @@ defmodule Spectral.MixProject do
 
   defp deps do
     [
-      {:spectra, "~> 0.12.1"},
+      {:spectra,
+       github: "andreashasse/spectra", branch: "claude/mystifying-dirac-930c38", override: true},
       {:stream_data, "~> 1.1", only: :test},
       {:cover_diff, "~> 0.1.0", only: :test, runtime: false},
       # Code quality tools

--- a/mix.exs
+++ b/mix.exs
@@ -31,8 +31,7 @@ defmodule Spectral.MixProject do
 
   defp deps do
     [
-      {:spectra,
-       github: "andreashasse/spectra", branch: "claude/mystifying-dirac-930c38", override: true},
+      {:spectra, "~> 0.13.1"},
       {:stream_data, "~> 1.1", only: :test},
       {:cover_diff, "~> 0.1.0", only: :test, runtime: false},
       # Code quality tools

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Spectral.MixProject do
   def project do
     [
       app: :spectral,
-      version: "0.12.0",
+      version: "0.13.0",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/mix.lock
+++ b/mix.lock
@@ -12,6 +12,6 @@
   "makeup_elixir": {:hex, :makeup_elixir, "1.0.1", "e928a4f984e795e41e3abd27bfc09f51db16ab8ba1aebdba2b3a575437efafc2", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "7284900d412a3e5cfd97fdaed4f5ed389b8f2b4cb49efc0eb3bd10e2febf9507"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.3", "4252d5d4098da7415c390e847c814bad3764c94a814a0b4245176215615e1035", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "953297c02582a33411ac6208f2c6e55f0e870df7f80da724ed613f10e6706afd"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
-  "spectra": {:hex, :spectra, "0.12.1", "708bbe36f9f4daf64b17da53f87420f1c5f6e5e7ed2f1bbba69ee8f7d03c0d63", [:rebar3], [], "hexpm", "51f75322dfb3af4450b01a3130643c70d4ac36505f1fe61f6e331a66e681e8b3"},
+  "spectra": {:git, "https://github.com/andreashasse/spectra.git", "5cfc0be6ff37b775b599e1f4a3636a3ac08a6ccb", [branch: "claude/mystifying-dirac-930c38"]},
   "stream_data": {:hex, :stream_data, "1.3.0", "bde37905530aff386dea1ddd86ecbf00e6642dc074ceffc10b7d4e41dfd6aac9", [:mix], [], "hexpm", "3cc552e286e817dca43c98044c706eec9318083a1480c52ae2688b08e2936e3c"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -12,6 +12,6 @@
   "makeup_elixir": {:hex, :makeup_elixir, "1.0.1", "e928a4f984e795e41e3abd27bfc09f51db16ab8ba1aebdba2b3a575437efafc2", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "7284900d412a3e5cfd97fdaed4f5ed389b8f2b4cb49efc0eb3bd10e2febf9507"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.3", "4252d5d4098da7415c390e847c814bad3764c94a814a0b4245176215615e1035", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "953297c02582a33411ac6208f2c6e55f0e870df7f80da724ed613f10e6706afd"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
-  "spectra": {:git, "https://github.com/andreashasse/spectra.git", "5cfc0be6ff37b775b599e1f4a3636a3ac08a6ccb", [branch: "claude/mystifying-dirac-930c38"]},
+  "spectra": {:hex, :spectra, "0.13.1", "b250f046c0ebb3d41b30b97e7ef47b4838fdf702f319c90f854f84d4995f11e5", [:rebar3], [], "hexpm", "b964883070df0192cf0811f15b49aec21951451a964d386ae6b19dd6cee4488d"},
   "stream_data": {:hex, :stream_data, "1.3.0", "bde37905530aff386dea1ddd86ecbf00e6642dc074ceffc10b7d4e41dfd6aac9", [:mix], [], "hexpm", "3cc552e286e817dca43c98044c706eec9318083a1480c52ae2688b08e2936e3c"},
 }

--- a/test/spectral_field_aliases_test.exs
+++ b/test/spectral_field_aliases_test.exs
@@ -25,9 +25,7 @@ defmodule SpectralFieldAliasesTest do
         |> Jason.decode!()
 
       props = schema["properties"]
-      assert Map.has_key?(props, "firstName")
-      assert Map.has_key?(props, "lastName")
-      assert Map.has_key?(props, "birth_year")
+      assert %{"firstName" => _, "lastName" => _, "birth_year" => _} = props
       refute Map.has_key?(props, "first_name")
       refute Map.has_key?(props, "last_name")
     end
@@ -39,8 +37,7 @@ defmodule SpectralFieldAliasesTest do
       {:ok, json_io} = Spectral.encode(data, FieldAliasesModule, :partial)
       json = IO.iodata_to_binary(json_io)
       decoded = Jason.decode!(json)
-      assert decoded["firstName"] == "Alice"
-      assert Map.has_key?(decoded, "last_name")
+      assert %{"firstName" => "Alice", "last_name" => _} = decoded
       refute Map.has_key?(decoded, "birth_year")
       refute Map.has_key?(decoded, "first_name")
     end

--- a/test/spectral_field_aliases_test.exs
+++ b/test/spectral_field_aliases_test.exs
@@ -7,9 +7,7 @@ defmodule SpectralFieldAliasesTest do
       {:ok, json_io} = Spectral.encode(data, FieldAliasesModule, :t)
       json = IO.iodata_to_binary(json_io)
       decoded = Jason.decode!(json)
-      assert decoded["firstName"] == "Alice"
-      assert decoded["lastName"] == "Smith"
-      assert decoded["birth_year"] == 1990
+      assert %{"firstName" => "Alice", "lastName" => "Smith", "birth_year" => 1990} = decoded
       refute Map.has_key?(decoded, "first_name")
       refute Map.has_key?(decoded, "last_name")
     end
@@ -17,9 +15,7 @@ defmodule SpectralFieldAliasesTest do
     test "decode accepts aliased key names" do
       json = ~s({"firstName":"Bob","lastName":"Jones","birth_year":1985})
       {:ok, result} = Spectral.decode(json, FieldAliasesModule, :t)
-      assert result.first_name == "Bob"
-      assert result.last_name == "Jones"
-      assert result.birth_year == 1985
+      assert %{first_name: "Bob", last_name: "Jones", birth_year: 1985} = result
     end
 
     test "schema reflects aliased field names" do

--- a/test/spectral_field_aliases_test.exs
+++ b/test/spectral_field_aliases_test.exs
@@ -1,0 +1,95 @@
+defmodule SpectralFieldAliasesTest do
+  use ExUnit.Case, async: true
+
+  describe "field_aliases on struct type" do
+    test "encode uses aliased key names" do
+      data = %FieldAliasesModule{first_name: "Alice", last_name: "Smith", birth_year: 1990}
+      {:ok, json_io} = Spectral.encode(data, FieldAliasesModule, :t)
+      json = IO.iodata_to_binary(json_io)
+      decoded = Jason.decode!(json)
+      assert decoded["firstName"] == "Alice"
+      assert decoded["lastName"] == "Smith"
+      assert decoded["birth_year"] == 1990
+      refute Map.has_key?(decoded, "first_name")
+      refute Map.has_key?(decoded, "last_name")
+    end
+
+    test "decode accepts aliased key names" do
+      json = ~s({"firstName":"Bob","lastName":"Jones","birth_year":1985})
+      {:ok, result} = Spectral.decode(json, FieldAliasesModule, :t)
+      assert result.first_name == "Bob"
+      assert result.last_name == "Jones"
+      assert result.birth_year == 1985
+    end
+
+    test "schema reflects aliased field names" do
+      schema =
+        Spectral.schema(FieldAliasesModule, :t)
+        |> IO.iodata_to_binary()
+        |> Jason.decode!()
+
+      props = schema["properties"]
+      assert Map.has_key?(props, "firstName")
+      assert Map.has_key?(props, "lastName")
+      assert Map.has_key?(props, "birth_year")
+      refute Map.has_key?(props, "first_name")
+      refute Map.has_key?(props, "last_name")
+    end
+  end
+
+  describe "field_aliases + only compose correctly" do
+    test "only is applied first, then aliases on remaining fields" do
+      data = %FieldAliasesModule{first_name: "Alice", last_name: "Smith", birth_year: 1990}
+      {:ok, json_io} = Spectral.encode(data, FieldAliasesModule, :partial)
+      json = IO.iodata_to_binary(json_io)
+      decoded = Jason.decode!(json)
+      assert decoded["firstName"] == "Alice"
+      assert Map.has_key?(decoded, "last_name")
+      refute Map.has_key?(decoded, "birth_year")
+      refute Map.has_key?(decoded, "first_name")
+    end
+  end
+
+  describe "field_aliases on map type" do
+    test "encode uses aliased key for map literal field" do
+      data = %{key: "value"}
+      {:ok, json_io} = Spectral.encode(data, FieldAliasesModule, :map_t)
+      json = IO.iodata_to_binary(json_io)
+      decoded = Jason.decode!(json)
+      assert decoded["camelKey"] == "value"
+      refute Map.has_key?(decoded, "key")
+    end
+
+    test "decode accepts aliased key for map literal field" do
+      json = ~s({"camelKey":"hello"})
+      {:ok, result} = Spectral.decode(json, FieldAliasesModule, :map_t)
+      assert result.key == "hello"
+    end
+  end
+
+  describe "field_aliases validation" do
+    test "invalid aliases value (not binary) raises at compile time" do
+      assert_raise ArgumentError, ~r/field_aliases/, fn ->
+        Code.eval_string("""
+        defmodule InvalidAliasValue do
+          use Spectral
+          spectral(field_aliases: %{name: 123})
+          @type t :: %{name: String.t()}
+        end
+        """)
+      end
+    end
+
+    test "invalid aliases (not a map) raises at compile time" do
+      assert_raise ArgumentError, ~r/field_aliases/, fn ->
+        Code.eval_string("""
+        defmodule InvalidAliasType do
+          use Spectral
+          spectral(field_aliases: [:name])
+          @type t :: %{name: String.t()}
+        end
+        """)
+      end
+    end
+  end
+end

--- a/test/spectral_ref_propagation_test.exs
+++ b/test/spectral_ref_propagation_test.exs
@@ -1,0 +1,47 @@
+defmodule SpectralRefPropagationTest do
+  # Tests for field_aliases and only propagation through type references (spectra 0.13.1).
+  # These transforms were silently dropped at reference boundaries in 0.13.0.
+  use ExUnit.Case, async: true
+
+  describe "field_aliases on remote type reference" do
+    test "encode uses aliased keys when field_aliases is declared on a remote type ref" do
+      data = %TypeRefModule.Inner{first_name: "Alice", last_name: "Smith", secret: "x"}
+      {:ok, json_io} = Spectral.encode(data, TypeRefModule, :aliased_t)
+      decoded = json_io |> IO.iodata_to_binary() |> Jason.decode!()
+      assert decoded["firstName"] == "Alice"
+      assert decoded["lastName"] == "Smith"
+      refute Map.has_key?(decoded, "first_name")
+      refute Map.has_key?(decoded, "last_name")
+    end
+
+    test "decode accepts aliased keys when field_aliases is declared on a remote type ref" do
+      json = ~s({"firstName":"Bob","lastName":"Jones","secret":"y"})
+      {:ok, result} = Spectral.decode(json, TypeRefModule, :aliased_t)
+      assert result.first_name == "Bob"
+      assert result.last_name == "Jones"
+    end
+  end
+
+  describe "only on remote type reference" do
+    test "only filters fields when declared on a remote type ref" do
+      data = %TypeRefModule.Inner{first_name: "Alice", last_name: "Smith", secret: "classified"}
+      {:ok, json_io} = Spectral.encode(data, TypeRefModule, :restricted_t)
+      decoded = json_io |> IO.iodata_to_binary() |> Jason.decode!()
+      assert Map.has_key?(decoded, "first_name")
+      assert Map.has_key?(decoded, "last_name")
+      refute Map.has_key?(decoded, "secret")
+    end
+  end
+
+  describe "only + field_aliases on remote type reference" do
+    test "only and field_aliases compose when declared on a remote type ref" do
+      data = %TypeRefModule.Inner{first_name: "Alice", last_name: "Smith", secret: "classified"}
+      {:ok, json_io} = Spectral.encode(data, TypeRefModule, :restricted_aliased_t)
+      decoded = json_io |> IO.iodata_to_binary() |> Jason.decode!()
+      assert decoded["firstName"] == "Alice"
+      assert Map.has_key?(decoded, "last_name")
+      refute Map.has_key?(decoded, "first_name")
+      refute Map.has_key?(decoded, "secret")
+    end
+  end
+end

--- a/test/spectral_ref_propagation_test.exs
+++ b/test/spectral_ref_propagation_test.exs
@@ -8,8 +8,7 @@ defmodule SpectralRefPropagationTest do
       data = %TypeRefModule.Inner{first_name: "Alice", last_name: "Smith", secret: "x"}
       {:ok, json_io} = Spectral.encode(data, TypeRefModule, :aliased_t)
       decoded = json_io |> IO.iodata_to_binary() |> Jason.decode!()
-      assert decoded["firstName"] == "Alice"
-      assert decoded["lastName"] == "Smith"
+      assert %{"firstName" => "Alice", "lastName" => "Smith"} = decoded
       refute Map.has_key?(decoded, "first_name")
       refute Map.has_key?(decoded, "last_name")
     end
@@ -17,8 +16,7 @@ defmodule SpectralRefPropagationTest do
     test "decode accepts aliased keys when field_aliases is declared on a remote type ref" do
       json = ~s({"firstName":"Bob","lastName":"Jones","secret":"y"})
       {:ok, result} = Spectral.decode(json, TypeRefModule, :aliased_t)
-      assert result.first_name == "Bob"
-      assert result.last_name == "Jones"
+      assert %{first_name: "Bob", last_name: "Jones"} = result
     end
   end
 

--- a/test/spectral_ref_propagation_test.exs
+++ b/test/spectral_ref_propagation_test.exs
@@ -36,8 +36,7 @@ defmodule SpectralRefPropagationTest do
       data = %TypeRefModule.Inner{first_name: "Alice", last_name: "Smith", secret: "classified"}
       {:ok, json_io} = Spectral.encode(data, TypeRefModule, :restricted_aliased_t)
       decoded = json_io |> IO.iodata_to_binary() |> Jason.decode!()
-      assert decoded["firstName"] == "Alice"
-      assert Map.has_key?(decoded, "last_name")
+      assert %{"firstName" => "Alice", "last_name" => _} = decoded
       refute Map.has_key?(decoded, "first_name")
       refute Map.has_key?(decoded, "secret")
     end

--- a/test/spectral_ref_propagation_test.exs
+++ b/test/spectral_ref_propagation_test.exs
@@ -25,8 +25,7 @@ defmodule SpectralRefPropagationTest do
       data = %TypeRefModule.Inner{first_name: "Alice", last_name: "Smith", secret: "classified"}
       {:ok, json_io} = Spectral.encode(data, TypeRefModule, :restricted_t)
       decoded = json_io |> IO.iodata_to_binary() |> Jason.decode!()
-      assert Map.has_key?(decoded, "first_name")
-      assert Map.has_key?(decoded, "last_name")
+      assert %{"first_name" => _, "last_name" => _} = decoded
       refute Map.has_key?(decoded, "secret")
     end
   end

--- a/test/support/field_aliases_module.ex
+++ b/test/support/field_aliases_module.ex
@@ -1,0 +1,26 @@
+defmodule FieldAliasesModule do
+  @moduledoc false
+  use Spectral
+
+  defstruct [:first_name, :last_name, :birth_year]
+
+  spectral(field_aliases: %{first_name: "firstName", last_name: "lastName"})
+
+  @type t :: %FieldAliasesModule{
+          first_name: String.t() | nil,
+          last_name: String.t() | nil,
+          birth_year: non_neg_integer() | nil
+        }
+
+  spectral(field_aliases: %{first_name: "firstName"}, only: [:first_name, :last_name])
+
+  @type partial :: %FieldAliasesModule{
+          first_name: String.t() | nil,
+          last_name: String.t() | nil,
+          birth_year: non_neg_integer() | nil
+        }
+
+  spectral(field_aliases: %{key: "camelKey"})
+
+  @type map_t :: %{key: String.t()}
+end

--- a/test/support/type_ref_module.ex
+++ b/test/support/type_ref_module.ex
@@ -1,0 +1,34 @@
+defmodule TypeRefModule do
+  @moduledoc false
+  # Tests for field_aliases and only propagation through type references (0.13.1)
+  use Spectral
+
+  defmodule Inner do
+    @moduledoc false
+    use Spectral
+
+    defstruct [:first_name, :last_name, :secret]
+
+    @type t :: %Inner{
+            first_name: String.t() | nil,
+            last_name: String.t() | nil,
+            secret: String.t() | nil
+          }
+  end
+
+  # field_aliases on a remote type reference (sp_remote_type)
+  spectral(field_aliases: %{first_name: "firstName", last_name: "lastName"})
+  @type aliased_t :: Inner.t()
+
+  # only on a remote type reference
+  spectral(only: [:first_name, :last_name])
+  @type restricted_t :: Inner.t()
+
+  # field_aliases + only on a remote type reference
+  spectral(only: [:first_name, :last_name], field_aliases: %{first_name: "firstName"})
+  @type restricted_aliased_t :: Inner.t()
+
+  # field_aliases on a local user type ref (sp_user_type_ref)
+  spectral(field_aliases: %{first_name: "firstName"})
+  @type local_aliased_t :: aliased_t()
+end


### PR DESCRIPTION
## Summary

- Switches the `:spectra` dep to the released hex `~> 0.13.1`, which includes `field_aliases` support (0.13.0) and type-reference propagation fixes (0.13.1)
- Exposes `field_aliases` through the `spectral/1` macro as `field_aliases: %{first_name: "firstName"}`
- Adds tests for field aliasing (structs, maps, schema output, `only` composition, compile-time validation) and for `only`/`field_aliases` propagation through remote type refs (new in 0.13.1)
- Documents `field_aliases` in the README: bullet in "Supported fields" list, dedicated "Field Aliases" section, and type-ref propagation notes

## What changed

**`lib/spectral.ex`** — `apply_type_doc/4` extracts `field_aliases` from the doc map and applies transforms in this order: `only` filter → `field_aliases` → `add_doc_to_type` (which rejects unknown keys, so both must be stripped and applied before it). A `validate_field_aliases/1` helper validates the map at compile time, consistent with the existing `validate_only/1` pattern. `field_aliases` is documented in the `spectral/1` macro docs.

**`mix.exs` / `mix.lock`** — dep updated from `~> 0.12.1` to `~> 0.13.1` (hex release).

**`README.md`** — `field_aliases` added to the supported fields bullet list; new "Field Aliases" section with encode/decode/schema examples; `only` and field-alias type-ref propagation documented.

## Reviewer notes

- `apply_field_aliases/2` was originally private in the Erlang lib. It is now exported as part of 0.13.1.
- `validate_field_aliases/1` remains private in Erlang; the Elixir validation is a small parallel implementation (keys: atom or integer, values: binary).
- All tests pass. Credo clean. Dialyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)