### PR TITLE
ci: add Elixir 1.20 RC to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             otp: "27.3"
           - elixir: "1.19"
             otp: "28.3"
-          - elixir: "1.20.0-rc.0"
+          - elixir: "1.20.0-rc.4"
             otp: "28.3"
             continue-on-error: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.continue-on-error == true }}
 
     strategy:
       matrix:
@@ -18,6 +19,9 @@ jobs:
             otp: "27.3"
           - elixir: "1.19"
             otp: "28.3"
+          - elixir: "1.20.0-rc.0"
+            otp: "28.3"
+            continue-on-error: true
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.continue-on-error == true }}
-
     strategy:
       matrix:
         include:
@@ -21,7 +19,6 @@ jobs:
             otp: "28.3"
           - elixir: "1.20.0-rc.4"
             otp: "28.3"
-            continue-on-error: true
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What changed

Adds an Elixir `1.20.0-rc.0` + OTP `28.3` entry to the CI matrix.

## Why

Catch compatibility issues early while 1.20 is still in RC, without blocking merges if the RC itself has rough edges.

## Details

- New matrix entry uses `continue-on-error: true` so a failing RC job doesn't fail the overall workflow.
- The job-level `continue-on-error: ${{ matrix.continue-on-error == true }}` expression defaults to `false` for existing entries (1.18, 1.19), leaving their behaviour unchanged.
- Update `1.20.0-rc.0` to the latest published RC version as needed — check [hex.pm Elixir installs](https://hex.pm/installs/elixir) for available versions.